### PR TITLE
Allow for the config file to be absent

### DIFF
--- a/lib/cleo_katas/configuration.rb
+++ b/lib/cleo_katas/configuration.rb
@@ -5,8 +5,15 @@ require 'delegate'
 module CleoKatas
   # Stores configured preferences for this user
   class Configuration < DelegateClass(Hash)
+    CONFIG_FILE_PATH = '.cleo-katas.yml'
+
     def initialize
-      super(YAML.load_file('.cleo-katas.yml'))
+      if File.file?(CONFIG_FILE_PATH)
+        super(YAML.load_file(CONFIG_FILE_PATH))
+      else
+        # Blank config
+        super(Hash.new(''))
+      end
     end
 
     # The preferred username for this User. Will fall back to their git config username or their


### PR DESCRIPTION
Before:

```
➜  cleo-katas git:(main) bin/cleo_katas attempt rock_paper_scissors
/Users/fell/.asdf/installs/ruby/3.2.2/lib/ruby/3.2.0/psych.rb:670:in `initialize': No such file or directory @ rb_sysopen - .cleo-katas.yml (Errno::ENOENT)
```

Now:

```
➜  cleo-katas git:(main) ✗ bin/cleo_katas attempt rock_paper_scissors
      create  katas/rock_paper_scissors/fell
```