### PR TITLE
Fix linter GH workflow

### DIFF
--- a/.github/workflows/ruby-lint.yml
+++ b/.github/workflows/ruby-lint.yml
@@ -27,8 +27,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
+      uses: ruby/setup-ruby@v1
+      with:
           ruby-version: 3.4.1
     - name: Run cops
       run: bundle exec rubocop

--- a/.github/workflows/ruby-lint.yml
+++ b/.github/workflows/ruby-lint.yml
@@ -30,5 +30,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
           ruby-version: 3.4.1
+    - name: Install gems
+      run: bundle install
     - name: Run cops
       run: bundle exec rubocop

--- a/lib/cleo_katas/cli.rb
+++ b/lib/cleo_katas/cli.rb
@@ -13,6 +13,8 @@ module CleoKatas
     source_root File.expand_path('templates', __dir__)
 
     desc 'create', 'Create a new kata'
+    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
     def create(kata_name)
       self.kata = kata_name
 
@@ -35,6 +37,8 @@ module CleoKatas
         File.join(Dir.pwd, 'katas', kata_number_name.to_s, 'source', 'test.rb')
       )
     end
+    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize
 
     desc 'list', 'List all available katas'
     def list
@@ -43,9 +47,9 @@ module CleoKatas
         say "#{kata_file.number}: #{kata_file.name}"
       end
     end
-
-    # rubocop:disable Metrics/MethodLength
     desc 'attempt DIRECTORY', 'Create a new kata attempt in your own directory'
+    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
     def attempt(kata_name)
       self.kata = kata_name
 
@@ -77,6 +81,7 @@ module CleoKatas
       say "Created new kata attempt directory at #{target_directory} with a main.rb file"
     end
     # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize
 
     protected
 

--- a/lib/cleo_katas/cli.rb
+++ b/lib/cleo_katas/cli.rb
@@ -22,18 +22,17 @@ module CleoKatas
 
       say "Creating kata #{kata_number_name}"
 
-      empty_directory(File.join(Dir.pwd, 'katas', "#{kata_number_name}"))
-      empty_directory(File.join(Dir.pwd, 'katas', "#{kata_number_name}", 'source'))
+      empty_directory(File.join(Dir.pwd, 'katas', kata_number_name.to_s))
+      empty_directory(File.join(Dir.pwd, 'katas', kata_number_name.to_s, 'source'))
       template('README.md.erb',
-               File.join(Dir.pwd, 'katas', "#{kata_number_name}", 'README.md')
-      )
+               File.join(Dir.pwd, 'katas', kata_number_name.to_s, 'README.md'))
       template(
         'main.rb.erb',
-                File.join(Dir.pwd, 'katas', "#{kata_number_name}", 'source', 'main.rb')
+        File.join(Dir.pwd, 'katas', kata_number_name.to_s, 'source', 'main.rb')
       )
       template(
         'test.rb.erb',
-               File.join(Dir.pwd, 'katas', "#{kata_number_name}", 'source', 'test.rb')
+        File.join(Dir.pwd, 'katas', kata_number_name.to_s, 'source', 'test.rb')
       )
     end
 
@@ -52,7 +51,7 @@ module CleoKatas
 
       begin
         kata_file.numbered_name
-      rescue
+      rescue StandardError
         say "Kata #{kata_name} not found"
         return
       end
@@ -61,7 +60,7 @@ module CleoKatas
       target_directory = File.join(Dir.pwd, 'katas', kata_file.numbered_name, username)
       readme_target_file = File.join(target_directory, 'README.md')
 
-      directory(source_directory,target_directory)
+      directory(source_directory, target_directory)
       copy_file(kata_file.path, readme_target_file)
       append_file(readme_target_file, <<~MARKDOWN)
 
@@ -80,7 +79,6 @@ module CleoKatas
     # rubocop:enable Metrics/MethodLength
 
     protected
-
 
     def kata_class_name
       kata.to_s.split(/[^a-z0-9]+/i).map(&:capitalize).join


### PR DESCRIPTION
@Bodacious @AgentAntelope

(Description rewritten for clarity)

I was taking a look at these katas, and noticed that the linter workflow was failing.

I thought it was just just some indentation introduced in https://github.com/meetcleo/cleo-katas/commit/2d2f666ec4821bf7b9f0036a05b42510f359e9a4#diff-d9b1e9426044e1fe3466264cefe8991cbfae33502e166b84665579a46851f830L32-R32, which raises a syntax error when parsing the YAML: [latest run of this workflow](https://github.com/meetcleo/cleo-katas/actions/runs/13288409831).

After fixing that, I had to tweak the workflow to ensure that `bundle install` is run so we can then use `rubocop`, and that surfaced some linting errors.

In https://github.com/meetcleo/cleo-katas/pull/8/commits/5dc284dd25d0ca8d70a155601b50db1962535091 I chose to disable two cops for a couple of methods, since those two methods are quite procedural and I'm not sure refactoring them to satisfy the cops would make them more clear.

This is a [successful workflow run](https://github.com/lorenzoplanas/cleo-katas/actions/runs/17726281122/job/50367504467) in my fork.